### PR TITLE
chore: remove ksuid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ tracing = "0.1.41"
 url = { version = "2.5.4", features = ["serde"] }
 chrono = { version = "0.4.40", features = ["serde"] }
 derive_builder = "0.20.2"
-ksuid = "0.2.0"
 bytes = "1.10.1"
 uuid = { version = "1.16.0", features = ["serde"] }
 config = "0.15.11"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde_with = "3.12.0"
+rand = "0.9.1"
+
 actix-web = { version = "4.10.2", optional = true, features = ["rustls"] }
 rdkafka = { version = "0.38.0", optional = true, features = [
     "cmake-build",

--- a/src/services/transactor/comm/mod.rs
+++ b/src/services/transactor/comm/mod.rs
@@ -16,14 +16,15 @@
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{self as json, Value};
 
+use super::tx::{Doc, Obj, Tx, TxDomainEvent};
+use crate::services::core::Ref;
+use crate::services::transactor::document::generate_object_id;
 use crate::{
     Result,
     services::{HttpClient, JsonClient},
 };
 
 mod message;
-use super::tx::{Doc, Obj, Tx, TxDomainEvent};
-use crate::services::core::Ref;
 pub use message::*;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -81,7 +82,7 @@ impl<T: Serialize> super::Transaction for Envelope<T> {
                         class: Ref::from(crate::services::core::class::TxDomainEvent),
                     },
 
-                    id: ksuid::Ksuid::generate().to_hex(),
+                    id: generate_object_id(),
                     space: "core:space:Tx".to_string(),
 
                     modified_on: None,


### PR DESCRIPTION
It pulls in a really old version of rand, making it incompatible with wasm32-unknown-unknown. Switched to the same document ID generation as the TypeScript client.