### PR TITLE
feat: domain request method for `TransactorClient`

### DIFF
--- a/src/services/core/classes.rs
+++ b/src/services/core/classes.rs
@@ -1,0 +1,1 @@
+pub type OperationDomain = String;

--- a/src/services/core/mod.rs
+++ b/src/services/core/mod.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 //
 
+pub mod classes;
 pub(crate) mod ser;
+pub mod storage;
 
 use crate::services::transactor::tx::Doc;
 use serde::{Deserialize, Serialize};

--- a/src/services/core/storage.rs
+++ b/src/services/core/storage.rs
@@ -1,0 +1,15 @@
+use super::classes::OperationDomain;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DomainResult<T> {
+    pub domain: OperationDomain,
+    pub value: T,
+}
+
+impl<T: PartialEq> PartialEq for DomainResult<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.domain.eq(&other.domain) && self.value.eq(&other.value)
+    }
+}

--- a/src/services/transactor/backend/mod.rs
+++ b/src/services/transactor/backend/mod.rs
@@ -1,6 +1,9 @@
 use crate::Result;
 use crate::services::TokenProvider;
 use crate::services::core::WorkspaceUuid;
+use crate::services::core::classes::OperationDomain;
+use crate::services::core::storage::DomainResult;
+use crate::services::transactor::Transaction;
 use crate::services::transactor::methods::Method;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -23,6 +26,19 @@ pub trait Backend: Clone + TokenProvider + 'static {
         method: Method,
         body: &Q,
     ) -> Result<T>;
+
+    async fn domain_request<T: DeserializeOwned + Send, Q: Serialize>(
+        &self,
+        domain: OperationDomain,
+        operation: &str,
+        params: &Q,
+    ) -> Result<DomainResult<T>>;
+
+    async fn tx_raw<T: Serialize, R: DeserializeOwned + Send>(&self, tx: T) -> Result<R>;
+
+    async fn tx<T: Transaction, R: DeserializeOwned + Send>(&self, tx: T) -> Result<R> {
+        self.tx_raw(tx.to_value()?).await
+    }
 
     fn base(&self) -> &Url;
 

--- a/src/services/transactor/methods.rs
+++ b/src/services/transactor/methods.rs
@@ -24,6 +24,7 @@ api_methods!(
     FindAll: "find-all", "findAll",
     EnsurePerson: "ensure-person", "ensurePerson",
     Tx: "tx", "tx",
+    Request: "request", "domainRequest",
     Event: "event", "event",
     Ping: "ping", "ping",
     Hello: "hello", "hello",

--- a/src/services/transactor/tx.rs
+++ b/src/services/transactor/tx.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 
+use crate::services::core::classes::OperationDomain;
 use crate::services::core::ser::Data;
 use crate::services::core::{PersonId, Ref, Timestamp};
 use crate::services::event::{Class, Event};
@@ -129,8 +130,6 @@ impl Class for TxRemoveDoc {
 }
 
 impl Event for TxRemoveDoc {}
-
-pub type OperationDomain = String;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TxDomainEvent<T> {


### PR DESCRIPTION
To be used like so:

```rust
let messages = tx
    .domain_request::<Vec<Message>, _>(
        OperationDomain::from("communication"),
        "findMessages",
        &FindMessagesParams::default(),
    )
    .await;
```